### PR TITLE
Don't raise error if ray already initialized.

### DIFF
--- a/fitsmap/convert.py
+++ b/fitsmap/convert.py
@@ -1081,6 +1081,7 @@ def files_to_map(
     # to the console. These should be changed during development
     debug = os.getenv("FITSMAP_DEBUG", "False").lower() == "true"
     ray.init(
+        ignore_reinit_error=True,
         include_dashboard=debug,  # during dev == True
         configure_logging=~debug,  # during dev == False
         logging_level=logging.INFO


### PR DESCRIPTION
I was having problems running fitsmap via `convert.dir_to_map` on a certain cluster using slurm.  A little digging suggests that on clusters where slurm does not provide exclusive node access `ray` still attempts to use all cores on the node, leading to errors.

The errors can be avoided by initializing ray with only a single cpu (I haven't checked if it works using the number of cpus requested via slurm) before calling fitsmap, but only if ray is then re-initialized within fitsmap with `ignore_reinit_error=True`.  

I'm not sure if this is the best way to address the issue, but thought I'd provide the fix in case it's helpful. Happy to close this and just raise an issue or rework this PR if you have suggestions.