### PR TITLE
Adress get_cmap Deprecation

### DIFF
--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest ] #, windows-latest, macos-latest]
-        python-version: ["3.7"] # TODO: decide how many versions to support
+        python-version: ["3.8"] # TODO: decide how many versions to support
 
     runs-on: ${{ matrix.os }}
 

--- a/fitsmap/cartographer.py
+++ b/fitsmap/cartographer.py
@@ -453,9 +453,11 @@ def build_index_js(
             leaflet_layer_control_declaration(image_layer_dicts, marker_layer_dicts),
             "",
             "// Search ======================================================================",
-            leaflet_search_control_declaration(marker_layer_dicts)
-            if len(marker_layer_dicts)
-            else "",
+            (
+                leaflet_search_control_declaration(marker_layer_dicts)
+                if len(marker_layer_dicts)
+                else ""
+            ),
             "",
             "// Map event setup =============================================================",
             loading_screen_js(image_layer_dicts),

--- a/fitsmap/convert.py
+++ b/fitsmap/convert.py
@@ -1098,9 +1098,9 @@ def files_to_map(
     ray.init(
         include_dashboard=debug,  # during dev == True
         configure_logging=~debug,  # during dev == False
-        logging_level=logging.INFO
-        if debug
-        else logging.CRITICAL,  # during dev == logging.INFO, test == logging.CRITICAL
+        logging_level=(
+            logging.INFO if debug else logging.CRITICAL
+        ),  # during dev == logging.INFO, test == logging.CRITICAL
         log_to_driver=debug,  # during dev = True
     )
 

--- a/fitsmap/convert.py
+++ b/fitsmap/convert.py
@@ -406,7 +406,7 @@ def build_mpl_objects(
                                                          needed to create a tile
     """
     mpl_norm = simple_norm(array, **norm_kwargs)
-    mpl_cmap = copy.copy(mpl.cm.get_cmap(MPL_CMAP))
+    mpl_cmap = copy.copy(mpl.colormaps[MPL_CMAP])
     mpl_cmap.set_bad(color=(0, 0, 0, 0))
     return mpl_norm, mpl_cmap
 


### PR DESCRIPTION
Fixes deprecation of `cm.get_cmap` since matplotlib 3.7. This will no longer work in latest versions of matplotlib and should maintain compatibility with older versions. 